### PR TITLE
Quality of life improvements and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/.coursier
 bin/.scalafmt*
 results/
 *.iprof
+.idea

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
                 os.remove('build.sbt')
 
             if os.path.exists(os.path.join('confs', conf, 'plugins.sbt')):
-                sh.copyfile(os.path.join('confs', conf, 'plugins.sbt'), 'project/build.sbt')
+                sh.copyfile(os.path.join('confs', conf, 'plugins.sbt'), 'project/plugins.sbt')
             else:
                 os.remove('project/plugins.sbt')
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -35,7 +35,7 @@ def run(cmd):
     return subp.check_output(cmd)
 
 def compile(bench, compilecmd):
-    cmd = [sbt, 'clean']
+    cmd = [sbt, '-J-Xmx2G', 'clean']
     cmd.append('set mainClass in Compile := Some("{}")'.format(bench))
     cmd.append(compilecmd)
     return run(cmd)


### PR DESCRIPTION
- Ignore Intellij files.
- Give sbt 2g for compilation, same as with the travis job on scala-native.